### PR TITLE
Update SPEC file

### DIFF
--- a/NetworkManager-sstp.spec
+++ b/NetworkManager-sstp.spec
@@ -5,7 +5,7 @@ Summary:   NetworkManager VPN plugin for SSTP
 Name:      NetworkManager-sstp
 Epoch:     1
 Version:   0.9.10
-Release:   3%{snapshot}%{?dist}
+Release:   4%{snapshot}%{?dist}
 License:   GPLv2+
 URL:       http://www.gnome.org/projects/NetworkManager/
 Group:     System Environment/Base
@@ -14,7 +14,7 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-root
 
 BuildRequires: gtk3-devel
 BuildRequires: dbus-devel
-BuildRequires: NetworkManager-devel
+BuildRequires: NetworkManager-devel >= 0.9.10
 BuildRequires: NetworkManager-glib-devel
 BuildRequires: sstp-client-devel
 BuildRequires: glib2-devel
@@ -25,7 +25,7 @@ BuildRequires: libnm-gtk-devel
 
 Requires: gtk3
 Requires: dbus
-Requires: NetworkManager
+Requires: NetworkManager >= 0.9.10
 Requires: sstp-client
 Requires: ppp
 Requires: shared-mime-info
@@ -91,6 +91,8 @@ rm -f %{buildroot}%{_libdir}/pppd/%{ppp_version}/*.la
 %{_datadir}/gnome-vpn-properties/sstp/nm-sstp-dialog.ui
 
 %changelog
+* Thu Jun 11 2015 Marcin Zajaczkowski <mszpak ATT wp DOTT pl> - 1:0.9.10-4
+- Specify minimum required NetworkManager version - 0.9.10
 * Mon Jun 08 2015 Marcin Zajaczkowski <mszpak ATT wp DOTT pl> - 1:0.9.10-3
 - Minor changes to adjust configuration to Fedora requirements
 - Remove redundant Obsoletes tag 

--- a/NetworkManager-sstp.spec
+++ b/NetworkManager-sstp.spec
@@ -5,9 +5,9 @@ Summary:   NetworkManager VPN plugin for SSTP
 Name:      NetworkManager-sstp
 Epoch:     1
 Version:   0.9.10
-Release:   4%{snapshot}%{?dist}
+Release:   5%{snapshot}%{?dist}
 License:   GPLv2+
-URL:       http://www.gnome.org/projects/NetworkManager/
+URL:       https://github.com/enaess/network-manager-sstp/
 Group:     System Environment/Base
 Source:    https://downloads.sourceforge.net/sstp-client/%{name}-%{version}%{snapshot}.tar.bz2
 BuildRoot: %{_tmppath}/%{name}-%{version}-root
@@ -77,7 +77,8 @@ rm -f %{buildroot}%{_libdir}/pppd/%{ppp_version}/*.la
 %find_lang %{name}
 
 %files -f %{name}.lang
-%doc COPYING AUTHORS README ChangeLog
+%doc AUTHORS README ChangeLog
+%license COPYING
 %config(noreplace) %{_sysconfdir}/dbus-1/system.d/nm-sstp-service.conf
 %config(noreplace) %{_sysconfdir}/NetworkManager/VPN/nm-sstp-service.name
 %{_libexecdir}/nm-sstp-service
@@ -85,12 +86,16 @@ rm -f %{buildroot}%{_libdir}/pppd/%{ppp_version}/*.la
 %{_libdir}/pppd/%{ppp_version}/nm-sstp-pppd-plugin.so
 
 %files -n NetworkManager-sstp-gnome
-%doc COPYING AUTHORS README ChangeLog
+%doc AUTHORS README ChangeLog
+%license COPYING
 %{_libdir}/NetworkManager/lib*.so*
 %dir %{_datadir}/gnome-vpn-properties/sstp
 %{_datadir}/gnome-vpn-properties/sstp/nm-sstp-dialog.ui
 
 %changelog
+* Wed Jun 24 2015 Marcin Zajaczkowski <mszpak ATT wp DOTT pl> - 1:0.9.10-5
+- Change doc macro to license macro for COPYING file
+- Change URL to plugin project page instead if NetworkManager itself
 * Thu Jun 11 2015 Marcin Zajaczkowski <mszpak ATT wp DOTT pl> - 1:0.9.10-4
 - Specify minimum required NetworkManager version - 0.9.10
 * Mon Jun 08 2015 Marcin Zajaczkowski <mszpak ATT wp DOTT pl> - 1:0.9.10-3

--- a/NetworkManager-sstp.spec
+++ b/NetworkManager-sstp.spec
@@ -5,11 +5,11 @@ Summary:   NetworkManager VPN plugin for SSTP
 Name:      NetworkManager-sstp
 Epoch:     1
 Version:   0.9.10
-Release:   2%{snapshot}%{?dist}
+Release:   3%{snapshot}%{?dist}
 License:   GPLv2+
 URL:       http://www.gnome.org/projects/NetworkManager/
 Group:     System Environment/Base
-Source:    %{name}-%{version}%{snapshot}.tar.bz2
+Source:    https://downloads.sourceforge.net/sstp-client/%{name}-%{version}%{snapshot}.tar.bz2
 BuildRoot: %{_tmppath}/%{name}-%{version}-root
 
 BuildRequires: gtk3-devel
@@ -30,8 +30,6 @@ Requires: sstp-client
 Requires: ppp
 Requires: shared-mime-info
 Requires: gnome-keyring
-Requires: libnm-gtk
-Obsoletes: NetworkManager-sstp < 1:0.9.8.2-3
 
 %global _privatelibs libnm-sstp-properties[.]so.*
 %global __provides_exclude ^(%{_privatelibs})$
@@ -51,7 +49,6 @@ Requires: nm-connection-editor
 %else
 Requires: NetworkManager-gnome
 %endif
-Obsoletes: NetworkManager-sstp < 1:0.9.8.2-3
 
 %description -n NetworkManager-sstp-gnome
 This package contains software for integrating VPN capabilities with
@@ -65,9 +62,9 @@ if [ ! -f configure ]; then
   ./autogen.sh
 fi
 %configure \
-	--disable-static \
-	--enable-more-warnings=yes \
-	--with-pppd-plugin-dir=%{_libdir}/pppd/%{ppp_version}
+    --disable-static \
+    --enable-more-warnings=yes \
+    --with-pppd-plugin-dir=%{_libdir}/pppd/%{ppp_version}
 make %{?_smp_mflags}
 
 %install
@@ -81,8 +78,8 @@ rm -f %{buildroot}%{_libdir}/pppd/%{ppp_version}/*.la
 
 %files -f %{name}.lang
 %doc COPYING AUTHORS README ChangeLog
-%{_sysconfdir}/dbus-1/system.d/nm-sstp-service.conf
-%{_sysconfdir}/NetworkManager/VPN/nm-sstp-service.name
+%config(noreplace) %{_sysconfdir}/dbus-1/system.d/nm-sstp-service.conf
+%config(noreplace) %{_sysconfdir}/NetworkManager/VPN/nm-sstp-service.name
 %{_libexecdir}/nm-sstp-service
 %{_libexecdir}/nm-sstp-auth-dialog
 %{_libdir}/pppd/%{ppp_version}/nm-sstp-pppd-plugin.so
@@ -94,17 +91,20 @@ rm -f %{buildroot}%{_libdir}/pppd/%{ppp_version}/*.la
 %{_datadir}/gnome-vpn-properties/sstp/nm-sstp-dialog.ui
 
 %changelog
+* Mon Jun 08 2015 Marcin Zajaczkowski <mszpak ATT wp DOTT pl> - 1:0.9.10-3
+- Minor changes to adjust configuration to Fedora requirements
+- Remove redundant Obsoletes tag 
 * Tue Jun 02 2015 Eivind Naess <eivnaes@yahoo.com> - 1:0.9.10-2
 - Taking suggested changes for Gateway validation from George Joseph
 * Fri May 29 2015 Eivind Naess <eivnaes@yahoo.com> - 1:0.9.10-1
 - Upgraded the network-manager-sstp package to reflect mainstream 
   changes made to the network-manager-pptp counter part.
-* Sat Oct 12 2012 Eivind Naess <eivnaes@yahoo.com> - 1:0.9.4-2
+* Fri Oct 12 2012 Eivind Naess <eivnaes@yahoo.com> - 1:0.9.4-2
 - Fixed a bug that caused connection to be aborted with the message:
   "Connection was aborted, value of attribute is incorrect"
 * Sat May 05 2012 Eivind Naess <eivnaes@yahoo.com> - 1:0.9.4-1
 - Compiled against the latest network manager 0.9.4 sources.
-* Wed Mar 03 2012 Eivind Naess <eivnaes@yahoo.com> - 1:0.9.1-4
+* Sat Mar 03 2012 Eivind Naess <eivnaes@yahoo.com> - 1:0.9.1-4
 - Added back the 'refuese-eap=yes' by default in the configuration.
 * Wed Feb 08 2012 Eivind Naess <eivnaes@yahoo.com> - 1:0.9.1-3
 - Changed the pppd plugin to send MPPE keys on ip-up

--- a/NetworkManager-sstp.spec
+++ b/NetworkManager-sstp.spec
@@ -5,29 +5,25 @@ Summary:   NetworkManager VPN plugin for SSTP
 Name:      NetworkManager-sstp
 Epoch:     1
 Version:   0.9.10
-Release:   5%{snapshot}%{?dist}
+Release:   6%{snapshot}%{?dist}
 License:   GPLv2+
 URL:       https://github.com/enaess/network-manager-sstp/
-Group:     System Environment/Base
 Source:    https://downloads.sourceforge.net/sstp-client/%{name}-%{version}%{snapshot}.tar.bz2
-BuildRoot: %{_tmppath}/%{name}-%{version}-root
 
 BuildRequires: gtk3-devel
 BuildRequires: dbus-devel
-BuildRequires: NetworkManager-devel >= 0.9.10
-BuildRequires: NetworkManager-glib-devel
+BuildRequires: NetworkManager-glib-devel >= 0.9.10
 BuildRequires: sstp-client-devel
 BuildRequires: glib2-devel
-BuildRequires: ppp-devel
+BuildRequires: ppp-devel >= 2.4.6
 BuildRequires: libtool intltool gettext
 BuildRequires: libsecret-devel
 BuildRequires: libnm-gtk-devel
 
-Requires: gtk3
 Requires: dbus
 Requires: NetworkManager >= 0.9.10
 Requires: sstp-client
-Requires: ppp
+Requires: ppp >= 2.4.6
 Requires: shared-mime-info
 Requires: gnome-keyring
 
@@ -36,31 +32,24 @@ Requires: gnome-keyring
 %global __requires_exclude ^(%{_privatelibs})$
 
 %description
-This package contains software for integrating VPN capabilities with
+This package contains software for integrating VPN capabilities using
 the SSTP server with NetworkManager.
 
 %package -n NetworkManager-sstp-gnome
 Summary: NetworkManager VPN plugin for SSTP - GNOME files
 Group:   System Environment/Base
 
-Requires: NetworkManager-sstp = %{epoch}:%{version}-%{release}
-%if 0%{?fedora} > 17
+Requires: NetworkManager-sstp = %{version}-%{release}
 Requires: nm-connection-editor
-%else
-Requires: NetworkManager-gnome
-%endif
 
 %description -n NetworkManager-sstp-gnome
 This package contains software for integrating VPN capabilities with
 the SSTP server with NetworkManager (GNOME files).
 
 %prep
-%setup -q -n %{name}-%{version}
+%setup -q
 
 %build
-if [ ! -f configure ]; then
-  ./autogen.sh
-fi
 %configure \
     --disable-static \
     --enable-more-warnings=yes \
@@ -93,29 +82,43 @@ rm -f %{buildroot}%{_libdir}/pppd/%{ppp_version}/*.la
 %{_datadir}/gnome-vpn-properties/sstp/nm-sstp-dialog.ui
 
 %changelog
+* Thu Feb 04 2016 Marcin Zajaczkowski <mszpak ATT wp DOTT pl> - 1:0.9.10-6
+- Apply remarks after package review by Christopher Meng
+- Specify minimal required ppp version to >= 2.4.6
+
 * Wed Jun 24 2015 Marcin Zajaczkowski <mszpak ATT wp DOTT pl> - 1:0.9.10-5
 - Change doc macro to license macro for COPYING file
 - Change URL to plugin project page instead if NetworkManager itself
+
 * Thu Jun 11 2015 Marcin Zajaczkowski <mszpak ATT wp DOTT pl> - 1:0.9.10-4
 - Specify minimum required NetworkManager version - 0.9.10
+
 * Mon Jun 08 2015 Marcin Zajaczkowski <mszpak ATT wp DOTT pl> - 1:0.9.10-3
 - Minor changes to adjust configuration to Fedora requirements
 - Remove redundant Obsoletes tag 
+
 * Tue Jun 02 2015 Eivind Naess <eivnaes@yahoo.com> - 1:0.9.10-2
 - Taking suggested changes for Gateway validation from George Joseph
+
 * Fri May 29 2015 Eivind Naess <eivnaes@yahoo.com> - 1:0.9.10-1
 - Upgraded the network-manager-sstp package to reflect mainstream 
   changes made to the network-manager-pptp counter part.
+
 * Fri Oct 12 2012 Eivind Naess <eivnaes@yahoo.com> - 1:0.9.4-2
 - Fixed a bug that caused connection to be aborted with the message:
   "Connection was aborted, value of attribute is incorrect"
+
 * Sat May 05 2012 Eivind Naess <eivnaes@yahoo.com> - 1:0.9.4-1
 - Compiled against the latest network manager 0.9.4 sources.
+
 * Sat Mar 03 2012 Eivind Naess <eivnaes@yahoo.com> - 1:0.9.1-4
 - Added back the 'refuese-eap=yes' by default in the configuration.
+
 * Wed Feb 08 2012 Eivind Naess <eivnaes@yahoo.com> - 1:0.9.1-3
 - Changed the pppd plugin to send MPPE keys on ip-up
+
 * Sun Nov 20 2011 Eivind Naess <eivnaes@yahoo.com> - 1:0.9.1-2
 - Added proxy support
+
 * Sun Oct 02 2011 Eivind Naess <eivnaes@yahoo.com> - 1:0.9.0-1
 - Initial release


### PR DESCRIPTION
The packages has been (finally - thanks to @lkundrak) accepted and will be the part of the Fedora package library soon. This PR contains the SPEC version used in Fedora. You could merge it, if you like the changes.

Btw, do you plan to release 1.2.0 anytime soon? This version would be useful in Fedora 24 where NM 1.2.0 is used. However if you have something to finish before the release just let me know - I can use a snapshot version from master in the meantime.