### PR TITLE
Fix SSTP long name

### DIFF
--- a/po/ar.po
+++ b/po/ar.po
@@ -195,7 +195,7 @@ msgid "gtk-ok"
 msgstr ""
 
 #: ../properties/nm-sstp.c:50
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr ""
 
 #: ../properties/nm-sstp.c:51

--- a/po/as.po
+++ b/po/as.po
@@ -182,8 +182,8 @@ msgid "_Security:"
 msgstr "সুৰক্ষা (_S):"
 
 #: ../properties/nm-sstp.c:50
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
-msgstr "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
+msgstr "Secure Socket Tunneling Protocol (SSTP)"
 
 #: ../properties/nm-sstp.c:51
 msgid "Compatible with Microsoft and other SSTP VPN servers."

--- a/po/be@latin.po
+++ b/po/be@latin.po
@@ -173,7 +173,7 @@ msgid "_Security:"
 msgstr "_Biaśpieka:"
 
 #: ../properties/nm-sstp.c:50
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "Pratakoł tunelnaha PPP (SSTP)"
 
 #: ../properties/nm-sstp.c:51

--- a/po/bg.po
+++ b/po/bg.po
@@ -195,7 +195,7 @@ msgid "_Security:"
 msgstr "_Сигурност:"
 
 #: ../properties/nm-sstp.c:50
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "Тунелиращ протокол — точка до точка (SSTP)"
 
 #: ../properties/nm-sstp.c:51

--- a/po/bn_IN.po
+++ b/po/bn_IN.po
@@ -181,7 +181,7 @@ msgid "_Security:"
 msgstr "নিরাপত্তা: (_S)"
 
 #: ../properties/nm-sstp.c:50
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "পয়েন্ট-টু-পয়েন্ট টানেলিং প্রোটোকল (SSTP)"
 
 #: ../properties/nm-sstp.c:51

--- a/po/bs.po
+++ b/po/bs.po
@@ -252,7 +252,7 @@ msgstr ""
 "config: lcp-echo-failure i lcp-echo-interval"
 
 #: ../properties/nm-sstp.c:49
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "Point-to-Point tunelski protokol (SSTP)"
 
 #: ../properties/nm-sstp.c:50

--- a/po/ca.po
+++ b/po/ca.po
@@ -93,7 +93,7 @@ msgid "EAP"
 msgstr "EAP"
 
 #: ../properties/nm-sstp-editor-plugin.c:34
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "Protocol de túnel punt a punt (SSTP)"
 
 #: ../properties/nm-sstp-editor-plugin.c:35

--- a/po/ca@valencia.po
+++ b/po/ca@valencia.po
@@ -195,7 +195,7 @@ msgid "_Security:"
 msgstr "_Seguretat"
 
 #: ../properties/nm-sstp.c:50
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "Protocol de túnel punt a punt (SSTP)"
 
 #: ../properties/nm-sstp.c:51

--- a/po/cs.po
+++ b/po/cs.po
@@ -91,8 +91,8 @@ msgid "EAP"
 msgstr "EAP"
 
 #: ../properties/nm-sstp-editor-plugin.c:34
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
-msgstr "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
+msgstr "Secure Socket Tunneling Protocol (SSTP)"
 
 #: ../properties/nm-sstp-editor-plugin.c:35
 msgid "Compatible with Microsoft and other SSTP VPN servers."

--- a/po/da.po
+++ b/po/da.po
@@ -96,8 +96,8 @@ msgid "EAP"
 msgstr "EAP"
 
 #: ../properties/nm-sstp-editor-plugin.c:34
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
-msgstr "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
+msgstr "Secure Socket Tunneling Protocol (SSTP)"
 
 #: ../properties/nm-sstp-editor-plugin.c:35
 msgid "Compatible with Microsoft and other SSTP VPN servers."

--- a/po/de.po
+++ b/po/de.po
@@ -96,8 +96,8 @@ msgid "EAP"
 msgstr "EAP"
 
 #: ../properties/nm-sstp-editor-plugin.c:34
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
-msgstr "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
+msgstr "Secure Socket Tunneling Protocol (SSTP)"
 
 #: ../properties/nm-sstp-editor-plugin.c:35
 msgid "Compatible with Microsoft and other SSTP VPN servers."

--- a/po/el.po
+++ b/po/el.po
@@ -71,7 +71,7 @@ msgid "EAP"
 msgstr "EAP"
 
 #: ../properties/nm-sstp.c:56
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "Πρωτόκολλο Point-to-Point Tunneling (SSTP)"
 
 #: ../properties/nm-sstp.c:57

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -197,7 +197,7 @@ msgid "_Security:"
 msgstr "_Security:"
 
 #: ../properties/nm-sstp.c:50
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "Point-to-Point Tunnelling Protocol (SSTP)"
 
 #: ../properties/nm-sstp.c:51

--- a/po/eo.po
+++ b/po/eo.po
@@ -174,7 +174,7 @@ msgid "_Security:"
 msgstr "_Sekureco:"
 
 #: ../properties/nm-sstp.c:49
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr ""
 
 #: ../properties/nm-sstp.c:50

--- a/po/es.po
+++ b/po/es.po
@@ -93,7 +93,7 @@ msgid "EAP"
 msgstr "EAP"
 
 #: ../properties/nm-sstp-editor-plugin.c:34
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "Protocolo de túnel punto a punto (SSTP)"
 
 #: ../properties/nm-sstp-editor-plugin.c:35

--- a/po/et.po
+++ b/po/et.po
@@ -154,7 +154,7 @@ msgstr "_Lüüs (gateway):"
 msgid "_Security:"
 msgstr "_Turvalisus:"
 
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "Point-to-Point tunneli protokoll (SSTP)"
 
 msgid "Compatible with Microsoft and other SSTP VPN servers."

--- a/po/eu.po
+++ b/po/eu.po
@@ -260,7 +260,7 @@ msgstr ""
 "konfigurazioa: lcp-echo-failure eta lcp-echo-interval"
 
 #: ../properties/nm-sstp.c:49
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "Puntutik punturako tunelaren protokoloa (SSTP)"
 
 #: ../properties/nm-sstp.c:50

--- a/po/fa.po
+++ b/po/fa.po
@@ -196,7 +196,7 @@ msgid "_Security:"
 msgstr "_امنیت:"
 
 #: ../properties/nm-sstp.c:50
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "پروتکل تونل نقطه به نقطه (SSTP)"
 
 #: ../properties/nm-sstp.c:51

--- a/po/fi.po
+++ b/po/fi.po
@@ -234,8 +234,8 @@ msgid ""
 msgstr ""
 
 #: ../properties/nm-sstp.c:49
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
-msgstr "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
+msgstr "Secure Socket Tunneling Protocol (SSTP)"
 
 #: ../properties/nm-sstp.c:50
 msgid "Compatible with Microsoft and other SSTP VPN servers."

--- a/po/fr.po
+++ b/po/fr.po
@@ -276,7 +276,7 @@ msgstr ""
 "configuration : lcp-echo-failure et lcp-echo-interval"
 
 #: ../properties/nm-sstp.c:49
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "Protocole de tunnel Point-to-Point (SSTP)"
 
 #: ../properties/nm-sstp.c:50

--- a/po/fur.po
+++ b/po/fur.po
@@ -87,7 +87,7 @@ msgid "EAP"
 msgstr "EAP"
 
 #: ../properties/nm-sstp-editor-plugin.c:34
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "Protocol di tunel pont a pont (SSTP)"
 
 #: ../properties/nm-sstp-editor-plugin.c:35

--- a/po/gl.po
+++ b/po/gl.po
@@ -279,7 +279,7 @@ msgstr ""
 "opción: lcp-echo-failure e lcp-echo-interval"
 
 #: ../properties/nm-sstp.c:49
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "Protocolo de Túnel Punto a Punto (SSTP)"
 
 #: ../properties/nm-sstp.c:50

--- a/po/gu.po
+++ b/po/gu.po
@@ -195,8 +195,8 @@ msgid "_Security:"
 msgstr "સુરક્ષા (_S):"
 
 #: ../properties/nm-sstp.c:50
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
-msgstr "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
+msgstr "Secure Socket Tunneling Protocol (SSTP)"
 
 #: ../properties/nm-sstp.c:51
 msgid "Compatible with Microsoft and other SSTP VPN servers."

--- a/po/he.po
+++ b/po/he.po
@@ -191,7 +191,7 @@ msgid "_Security:"
 msgstr "_אבטחה:"
 
 #: ../properties/nm-sstp.c:50
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "פרוטוקול תיעול מנקודה לנקודה (SSTP)"
 
 #: ../properties/nm-sstp.c:51

--- a/po/hr.po
+++ b/po/hr.po
@@ -88,7 +88,7 @@ msgid "EAP"
 msgstr "EAP"
 
 #: ../properties/nm-sstp-editor-plugin.c:34
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "Točka-u-Točka protokol tuneliranja (SSTP)"
 
 #: ../properties/nm-sstp-editor-plugin.c:35

--- a/po/hu.po
+++ b/po/hu.po
@@ -90,7 +90,7 @@ msgid "EAP"
 msgstr "EAP"
 
 #: ../properties/nm-sstp-editor-plugin.c:34
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "Ponttól pontig alagutazási protokoll (SSTP)"
 
 #: ../properties/nm-sstp-editor-plugin.c:35

--- a/po/id.po
+++ b/po/id.po
@@ -89,8 +89,8 @@ msgid "EAP"
 msgstr "EAP"
 
 #: ../properties/nm-sstp-editor-plugin.c:34
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
-msgstr "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
+msgstr "Secure Socket Tunneling Protocol (SSTP)"
 
 #: ../properties/nm-sstp-editor-plugin.c:35
 msgid "Compatible with Microsoft and other SSTP VPN servers."

--- a/po/it.po
+++ b/po/it.po
@@ -93,8 +93,8 @@ msgid "EAP"
 msgstr "EAP"
 
 #: ../properties/nm-sstp-editor-plugin.c:34
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
-msgstr "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
+msgstr "Secure Socket Tunneling Protocol (SSTP)"
 
 #: ../properties/nm-sstp-editor-plugin.c:35
 msgid "Compatible with Microsoft and other SSTP VPN servers."

--- a/po/ja.po
+++ b/po/ja.po
@@ -181,8 +181,8 @@ msgid "_Security:"
 msgstr "セキュリティ(_S):"
 
 #: ../properties/nm-sstp.c:49
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
-msgstr "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
+msgstr "Secure Socket Tunneling Protocol (SSTP)"
 
 #: ../properties/nm-sstp.c:50
 msgid "Compatible with Microsoft and other SSTP VPN servers."

--- a/po/kn.po
+++ b/po/kn.po
@@ -185,7 +185,7 @@ msgid "_Security:"
 msgstr "ಸುರಕ್ಷತೆ(_S):"
 
 #: ../properties/nm-sstp.c:50
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "ಪಾಯಿಂಟ್-ಟು-ಪಾಯಿಂಟ್ ಟನಲಿಂಗ್ ಪ್ರೊಟೊಕಾಲ್ (SSTP)"
 
 #: ../properties/nm-sstp.c:51

--- a/po/ko.po
+++ b/po/ko.po
@@ -191,7 +191,7 @@ msgid "_Security:"
 msgstr "보안(_S):"
 
 #: ../properties/nm-sstp.c:50
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "포인트투포인트 터널링 프로토콜 (SSTP)"
 
 #: ../properties/nm-sstp.c:51

--- a/po/lt.po
+++ b/po/lt.po
@@ -92,7 +92,7 @@ msgid "EAP"
 msgstr "EAP"
 
 #: ../properties/nm-sstp-editor-plugin.c:34
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "PPP tuneliavimo protokolas (SSTP)"
 
 #: ../properties/nm-sstp-editor-plugin.c:35

--- a/po/lv.po
+++ b/po/lv.po
@@ -92,7 +92,7 @@ msgid "EAP"
 msgstr "EAP"
 
 #: ../properties/nm-sstp-editor-plugin.c:34
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "Divpunktu tunelēšanas protokols (SSTP)"
 
 #: ../properties/nm-sstp-editor-plugin.c:35

--- a/po/mr.po
+++ b/po/mr.po
@@ -180,8 +180,8 @@ msgid "_Security:"
 msgstr "सुरक्षा (_S):"
 
 #: ../properties/nm-sstp.c:50
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
-msgstr "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
+msgstr "Secure Socket Tunneling Protocol (SSTP)"
 
 #: ../properties/nm-sstp.c:51
 msgid "Compatible with Microsoft and other SSTP VPN servers."

--- a/po/nb.po
+++ b/po/nb.po
@@ -242,8 +242,8 @@ msgid ""
 msgstr ""
 
 #: ../properties/nm-sstp.c:49
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
-msgstr "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
+msgstr "Secure Socket Tunneling Protocol (SSTP)"
 
 #: ../properties/nm-sstp.c:50
 msgid "Compatible with Microsoft and other SSTP VPN servers."

--- a/po/nl.po
+++ b/po/nl.po
@@ -93,8 +93,8 @@ msgid "EAP"
 msgstr "EAP"
 
 #: ../properties/nm-sstp-editor-plugin.c:34
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
-msgstr "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
+msgstr "Secure Socket Tunneling Protocol (SSTP)"
 
 #: ../properties/nm-sstp-editor-plugin.c:35
 msgid "Compatible with Microsoft and other SSTP VPN servers."

--- a/po/oc.po
+++ b/po/oc.po
@@ -259,7 +259,7 @@ msgstr ""
 "configuracion : lcp-echo-failure e lcp-echo-interval"
 
 #: ../properties/nm-sstp.c:47
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "Protocòl de tunèl Point-to-Point (SSTP)"
 
 #: ../properties/nm-sstp.c:48

--- a/po/pa.po
+++ b/po/pa.po
@@ -248,7 +248,7 @@ msgid ""
 msgstr ""
 
 #: ../properties/nm-sstp.c:49
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "ਪੁਆਇੰਟ-ਟੂ-ਪੁਆਇੰਟ ਟਨਲਿੰਗ ਪਰੋਟੋਕਾਲ (SSTP)"
 
 #: ../properties/nm-sstp.c:50

--- a/po/pl.po
+++ b/po/pl.po
@@ -91,7 +91,7 @@ msgid "EAP"
 msgstr "EAP"
 
 #: ../properties/nm-sstp-editor-plugin.c:34
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "Protokół tunelowania Point-to-Point (SSTP)"
 
 #: ../properties/nm-sstp-editor-plugin.c:35

--- a/po/pt.po
+++ b/po/pt.po
@@ -70,7 +70,7 @@ msgid "EAP"
 msgstr "EAP"
 
 #: ../properties/nm-sstp.c:56
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "Protocolo de Tunneling ponto-a-ponto (SSTP)"
 
 #: ../properties/nm-sstp.c:57

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -97,7 +97,7 @@ msgid "EAP"
 msgstr "EAP"
 
 #: ../properties/nm-sstp-editor-plugin.c:34
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "Protocolo de Encapsulamento Ponto a Ponto (SSTP)"
 
 #: ../properties/nm-sstp-editor-plugin.c:35

--- a/po/ro.po
+++ b/po/ro.po
@@ -197,7 +197,7 @@ msgid "_Security:"
 msgstr "_Securitate:"
 
 #: ../properties/nm-sstp.c:50
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "Protocol de tunelare Punct la punct (SSTP)"
 
 #: ../properties/nm-sstp.c:51

--- a/po/ru.po
+++ b/po/ru.po
@@ -94,7 +94,7 @@ msgid "EAP"
 msgstr "EAP"
 
 #: ../properties/nm-sstp-editor-plugin.c:34
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "Туннельный протокол типа точка-точка (SSTP)"
 
 #: ../properties/nm-sstp-editor-plugin.c:35

--- a/po/sl.po
+++ b/po/sl.po
@@ -239,7 +239,7 @@ msgstr "Pošlji zahteve echo LCP za ohranjevanje povezave.\n"
 "Nastavitev: lcp-echo-failure in lcp-echo-interval"
 
 #: ../properties/nm-sstp.c:49
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "Point-to-Point protokol tuneliranja (SSTP)"
 
 #: ../properties/nm-sstp.c:50

--- a/po/sr.po
+++ b/po/sr.po
@@ -91,7 +91,7 @@ msgid "EAP"
 msgstr "ЕАП"
 
 #: ../properties/nm-sstp-editor-plugin.c:34
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "Проток тунелисања од тачке до тачке (ППТП)"
 
 #: ../properties/nm-sstp-editor-plugin.c:35

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -91,7 +91,7 @@ msgid "EAP"
 msgstr "EAP"
 
 #: ../properties/nm-sstp-editor-plugin.c:34
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "Protok tunelisanja od tačke do tačke (SSTP)"
 
 #: ../properties/nm-sstp-editor-plugin.c:35

--- a/po/sv.po
+++ b/po/sv.po
@@ -91,8 +91,8 @@ msgid "EAP"
 msgstr "EAP"
 
 #: ../properties/nm-sstp-editor-plugin.c:34
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
-msgstr "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
+msgstr "Secure Socket Tunneling Protocol (SSTP)"
 
 #: ../properties/nm-sstp-editor-plugin.c:35
 msgid "Compatible with Microsoft and other SSTP VPN servers."

--- a/po/ta.po
+++ b/po/ta.po
@@ -199,8 +199,8 @@ msgid "_Security:"
 msgstr "பாதுகாப்பு (_S):"
 
 #: ../properties/nm-sstp.c:50
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
-msgstr "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
+msgstr "Secure Socket Tunneling Protocol (SSTP)"
 
 #: ../properties/nm-sstp.c:51
 msgid "Compatible with Microsoft and other SSTP VPN servers."

--- a/po/te.po
+++ b/po/te.po
@@ -186,7 +186,7 @@ msgid "_Security:"
 msgstr "రక్షణ (_S):"
 
 #: ../properties/nm-sstp.c:50
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "పాయింట్-నుండి-పాయింట్ టన్నెలింగ్ ప్రోటోకాల్ (SSTP)"
 
 #: ../properties/nm-sstp.c:51

--- a/po/tr.po
+++ b/po/tr.po
@@ -72,7 +72,7 @@ msgid "EAP"
 msgstr "EAP"
 
 #: ../properties/nm-sstp.c:56
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "Noktadan Noktaya Tünelleme Protokolü (SSTP)"
 
 #: ../properties/nm-sstp.c:57

--- a/po/ug.po
+++ b/po/ug.po
@@ -189,7 +189,7 @@ msgid "_Security:"
 msgstr "بىخەتەرلىك(_S):"
 
 #: ../properties/nm-sstp.c:50
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "نۇقتىدىن نۇقتا تونېللاش كېلىشىمى(SSTP)"
 
 #: ../properties/nm-sstp.c:51

--- a/po/uk.po
+++ b/po/uk.po
@@ -195,8 +195,8 @@ msgid "_Security:"
 msgstr "_Шифрування:"
 
 #: ../properties/nm-sstp.c:50
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
-msgstr "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
+msgstr "Secure Socket Tunneling Protocol (SSTP)"
 
 #: ../properties/nm-sstp.c:51
 msgid "Compatible with Microsoft and other SSTP VPN servers."

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -178,7 +178,7 @@ msgid "_Security:"
 msgstr "安全性(_S)："
 
 #: ../properties/nm-sstp.c:49
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "点到点隧道协议(SSTP)"
 
 #: ../properties/nm-sstp.c:50

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -189,7 +189,7 @@ msgid "_Security:"
 msgstr "安全性(_S):"
 
 #: ../properties/nm-sstp.c:50
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "點對點穿隧通訊協定 (SSTP)"
 
 #: ../properties/nm-sstp.c:51

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -191,7 +191,7 @@ msgid "_Security:"
 msgstr "安全性(_S):"
 
 #: ../properties/nm-sstp.c:50
-msgid "Point-to-Point Tunneling Protocol (SSTP)"
+msgid "Secure Socket Tunneling Protocol (SSTP)"
 msgstr "點對點穿隧通訊協定 (SSTP)"
 
 #: ../properties/nm-sstp.c:51

--- a/properties/nm-sstp-editor-plugin.c
+++ b/properties/nm-sstp-editor-plugin.c
@@ -31,7 +31,7 @@
 #include "nm-utils/nm-vpn-plugin-utils.h"
 #endif
 
-#define SSTP_PLUGIN_NAME    _("Point-to-Point Tunneling Protocol (SSTP)")
+#define SSTP_PLUGIN_NAME    _("Secure Socket Tunneling Protocol (SSTP)")
 #define SSTP_PLUGIN_DESC    _("Compatible with Microsoft and other SSTP VPN servers.")
 
 /*****************************************************************************/


### PR DESCRIPTION
Changed Point-to-Point Tunneling Protocol to Secure Socket Tunneling Protocol across the project.

As [spotted](https://bugzilla.redhat.com/show_bug.cgi?id=2064985) by one of Fedora users, network-manager-sstp uses a long name inherited from the upstream project instead of the one corresponding to [SSTP](https://en.wikipedia.org/wiki/Secure_Socket_Tunneling_Protocol).

